### PR TITLE
Represent the actual object lifetimes with related lifetime scopes

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -16,10 +16,11 @@ namespace AutofacLifetimeTest
 	public class TestService
 	{
 		private readonly Func<TestResource> _resourceFactory;
-		public TestService(Func<TestResource> resourceFactory)
-		//private readonly Func<Owned<TestResource>> _resourceFactory;
-		//public TestService(Func<Owned<TestResource>> resourceFactory)
+		private readonly StateMediator _stateMediator;
+
+		public TestService(StateMediator stateMediator, Func<TestResource> resourceFactory)
 		{
+			_stateMediator = stateMediator;
 			_resourceFactory = resourceFactory;
 		}
 
@@ -32,24 +33,33 @@ namespace AutofacLifetimeTest
 		}
 	}
 
+	public class StateMediator
+	{
+		public string SomeSharedState { get; set; }
+	}
+
 	public class Program
 	{
 		private static void Main(string[] args)
 		{
 			var builder = new ContainerBuilder();
-			builder.RegisterType<TestService>().SingleInstance();
-			builder.RegisterType<TestResource>();
-			var container = builder.Build();
+			builder.RegisterType<TestService>().InstancePerLifetimeScope();
+			builder.RegisterType<TestResource>().InstancePerLifetimeScope();
+			builder.RegisterType<StateMediator>().SingleInstance();
 
-			var process = Process.GetCurrentProcess();
+			var container = builder.Build();
+			var process   = Process.GetCurrentProcess();
 
 			using (var scope = container.BeginLifetimeScope())
 			{
-				var service = scope.Resolve<TestService>();
 				long counter = 0;
 				while (true)
 				{
-					service.DoSomething();
+					using (var innerScope = scope.BeginLifetimeScope())
+					{
+						var service = innerScope.Resolve<TestService>();
+						service.DoSomething();
+					}
 					counter++;
 					if (counter % 100000 == 0)
 					{


### PR DESCRIPTION
There are actually 2 lifetimes in play here.  Represent those with 2 separate lifetime scopes and let autofac handle the cleanup